### PR TITLE
Fixes composer.json license to composer standard

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
 	"name": "aucor/dynamic-mo-loader",
 	"description": "Better text domain loading with object cache support for WordPress",
-	"license": "GPLv2 or later",
+	"license": "GPL-2.0+",
 	"type": "wordpress-muplugin",
 	"homepage": "https://github.com/aucor/dynamic-mo-loader",
 	"authors": [


### PR DESCRIPTION
https://getcomposer.org/doc/04-schema.md.

I have a git hook which automatically checks all included composer.json files and this one randomly popped out:

```
$ composer validate
./composer.json is valid, but with a few warnings
See https://getcomposer.org/doc/04-schema.md for details on the schema
License "GPLv2 or later" is not a valid SPDX license identifier, see https://spdx.org/licenses/ if you use an open license.
If the software is closed-source, you may use "proprietary" as license.
```
