### PR TITLE
PHP 7.3 support

### DIFF
--- a/inc/mo_dynamic.php
+++ b/inc/mo_dynamic.php
@@ -301,7 +301,7 @@ class WPPP_MO_dynamic extends Gettext_Translations {
 				$moitem->reader->seekto( $moitem->originals_table[$i+1] );
 				$original = $moitem->reader->read( $moitem->originals_table[$i] );
 
-				$j = strpos( $original, 0 );
+				$j = strpos( $original, '0' );
 				if ( $j !== false )
 					$original = substr( $original, 0, $i );
 			} else
@@ -398,7 +398,7 @@ class WPPP_MO_dynamic extends Gettext_Translations {
 							 || ord( $mo_original{$key_len} ) == 0 ) {
 							// strings can only match if they have the same length, no need to inspect otherwise
 
-							if ( false !== ( $i = strpos( $mo_original, 0 ) ) )
+							if ( false !== ( $i = strpos( $mo_original, '0' ) ) )
 								$cmpval = strncmp( $key, $mo_original, $i );
 							else 
 								$cmpval = strcmp( $key, $mo_original );
@@ -445,7 +445,7 @@ class WPPP_MO_dynamic extends Gettext_Translations {
 						$moitem->originals[$pivot] = $mo_original;
 					}
 
-					if ( false !== ( $i = strpos( $mo_original, 0 ) ) )
+					if ( false !== ( $i = strpos( $mo_original, '0' ) ) )
 						$cmpval = strncmp( $key, $mo_original, $i );
 					else
 						$cmpval = strcmp( $key, $mo_original );
@@ -497,7 +497,7 @@ class WPPP_MO_dynamic extends Gettext_Translations {
 		}
 		
 		if ( $t !== false ) {
-			if ( false !== ( $i = strpos( $t, 0 ) ) ) {
+			if ( false !== ( $i = strpos( $t, '0' ) ) ) {
 				return substr( $t, 0, $i );
 			} else {
 				return $t;
@@ -537,9 +537,9 @@ class WPPP_MO_dynamic extends Gettext_Translations {
 		}
 
 		if ( $t !== false ) {
-			if ( false !== ( $i = strpos( $t, 0 ) ) ) {
+			if ( false !== ( $i = strpos( $t, '0' ) ) ) {
 				if ( $count == 1 ) {
-					return substr ( $t, 0, $i );
+					return substr ( $t, '0', $i );
 				} else {
 					// only one plural form is assumed - needs improvement
 					return substr( $t, $i+1 );


### PR DESCRIPTION
Maybe needs more testing. On first load had

````
define('SAVEQUERIES', true);
define('WP_DEBUG', true);
define('SCRIPT_DEBUG', true);
````

And got `E_NOTICE: compact(): Undefined variable: context` (didn't take stack trace in this point), then disabled debug options and it works. When enabled debug options again, didn't get to repeat the problem as it works anyway. No caching enabled in dev environment.

AFAIK this fixes the fatal deprecated error for PHP 7.3 and issue #8, but needs to be checked by another pair of eyes.